### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/buildkitd.toml
+++ b/.github/buildkitd.toml
@@ -29,7 +29,7 @@ trace = true
     mirrors = ["https://ecr.sn0wdr1am.com"]
 
 [worker.oci]
-  max-parallelism = 2
+  max-parallelism = 3
 
 
 

--- a/.github/workflows/alpine.yml
+++ b/.github/workflows/alpine.yml
@@ -83,7 +83,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5.5.1
+        uses: docker/metadata-action@v5.6.1
         with:
           images: |
             name=snowdreamtech/go,enable=true
@@ -124,7 +124,7 @@ jobs:
         env:
           DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
       - name: Build and push
-        uses: docker/build-push-action@v6.9.0
+        uses: docker/build-push-action@v6.10.0
         with:
           context: alpine
           build-args: |

--- a/.github/workflows/alpine.yml
+++ b/.github/workflows/alpine.yml
@@ -63,7 +63,7 @@ jobs:
           driver-opts: |
             env.http_proxy=${{ env.http_proxy }}
             env.https_proxy=${{ env.http_proxy }}
-            env.no_proxy=${{ env.no_proxy }}
+            "env.no_proxy='${{ env.no_proxy}}'"
       - name: Login to DockerHub
         uses: docker/login-action@v3.3.0
         with:
@@ -128,9 +128,8 @@ jobs:
         with:
           context: alpine
           build-args: |
-            http_proxy=${{ env.http_proxy }}
-            https_proxy=${{ env.http_proxy }}
-            env.no_proxy=${{ env.no_proxy }}
+            "http_proxy=${{ env.http_proxy }}"
+            "https_proxy=${{ env.http_proxy }}"
             BUILDTIME=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
             VERSION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
             REVISION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -83,7 +83,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5.5.1
+        uses: docker/metadata-action@v5.6.1
         with:
           images: |
             name=snowdreamtech/go,enable=true
@@ -116,7 +116,7 @@ jobs:
         env:
           DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
       - name: Build and push
-        uses: docker/build-push-action@v6.9.0
+        uses: docker/build-push-action@v6.10.0
         with:
           context: debian
           build-args: |

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -63,7 +63,7 @@ jobs:
           driver-opts: |
             env.http_proxy=${{ env.http_proxy }}
             env.https_proxy=${{ env.http_proxy }}
-            env.no_proxy=${{ env.no_proxy }}
+            "env.no_proxy='${{ env.no_proxy}}'"
       - name: Login to DockerHub
         uses: docker/login-action@v3.3.0
         with:
@@ -120,9 +120,8 @@ jobs:
         with:
           context: debian
           build-args: |
-            http_proxy=${{ env.http_proxy }}
-            https_proxy=${{ env.http_proxy }}
-            env.no_proxy=${{ env.no_proxy }}
+            "http_proxy=${{ env.http_proxy }}"
+            "https_proxy=${{ env.http_proxy }}"
             BUILDTIME=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
             VERSION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
             REVISION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -15,6 +15,7 @@
         "ms-ceintl.vscode-language-pack-zh-hans",
         "github.vscode-github-actions",
         "ultram4rine.vscode-choosealicense",
-        "minherz.copyright-inserter"
+        "minherz.copyright-inserter",
+        "wdhongtw.gpg-indicator"
     ]
 }

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -9,13 +9,13 @@ LABEL org.opencontainers.image.authors="Snowdream Tech" \
       org.opencontainers.image.licenses="MIT" \
       org.opencontainers.image.source="https://github.com/snowdreamtech/go" \
       org.opencontainers.image.vendor="Snowdream Tech" \
-      org.opencontainers.image.version="1.22.8" \
+      org.opencontainers.image.version="1.23.1" \
       org.opencontainers.image.url="https://github.com/snowdreamtech/go"
 
 ENV GO111MODULE=on \
     GOPROXY=https://proxy.golang.org,https://goproxy.io,direct
     
-RUN apk add --no-cache go=1.22.8-r0
+RUN apk add --no-cache go@community=1.23.1-r0
 
 COPY docker-entrypoint.sh /usr/local/bin/
 

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -9,13 +9,13 @@ LABEL org.opencontainers.image.authors="Snowdream Tech" \
       org.opencontainers.image.licenses="MIT" \
       org.opencontainers.image.source="https://github.com/snowdreamtech/go" \
       org.opencontainers.image.vendor="Snowdream Tech" \
-      org.opencontainers.image.version="1.23.1" \
+      org.opencontainers.image.version="1.23.2" \
       org.opencontainers.image.url="https://github.com/snowdreamtech/go"
 
 ENV GO111MODULE=on \
     GOPROXY=https://proxy.golang.org,https://goproxy.io,direct
     
-RUN apk add --no-cache go@community=1.23.1-r0
+RUN apk add --no-cache go@community=1.23.2-r0
 
 COPY docker-entrypoint.sh /usr/local/bin/
 

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -9,19 +9,19 @@ LABEL org.opencontainers.image.authors="Snowdream Tech" \
     org.opencontainers.image.licenses="MIT" \
     org.opencontainers.image.source="https://github.com/snowdreamtech/go" \
     org.opencontainers.image.vendor="Snowdream Tech" \
-    org.opencontainers.image.version="1.22.8" \
+    org.opencontainers.image.version="1.23.1" \
     org.opencontainers.image.url="https://github.com/snowdreamtech/go"
 
-ENV GOLANG_VERSION=1.22.7-1~bpo12+1 \ 
-    GOROOT=/usr/lib/go-1.22 \
-    PATH=$PATH:/usr/lib/go-1.22/bin \
+ENV GOLANG_VERSION=1.23.1-3 \ 
+    GOROOT=/usr/lib/go-1.23 \
+    PATH=$PATH:/usr/lib/go-1.23/bin \
     GO111MODULE=on \
     GOPROXY=https://proxy.golang.org,https://goproxy.io,direct
 
 RUN set -eux \
     && apt-get -qqy update  \
     && apt-get -qqy install --no-install-recommends \ 
-    -t bookworm-backports golang-1.22=${GOLANG_VERSION} \
+    -t testing golang-1.23=${GOLANG_VERSION} \
     && apt-get -qqy --purge autoremove \
     && apt-get -qqy clean \
     && rm -rf /var/lib/apt/lists/* \

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -12,7 +12,7 @@ LABEL org.opencontainers.image.authors="Snowdream Tech" \
     org.opencontainers.image.version="1.23.2" \
     org.opencontainers.image.url="https://github.com/snowdreamtech/go"
 
-ENV GOLANG_VERSION=2:1.23~2 \ 
+ENV GOLANG_VERSION=1.23.2-1 \ 
     GOROOT=/usr/lib/go-1.23 \
     PATH=$PATH:/usr/lib/go-1.23/bin \
     GO111MODULE=on \

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -9,10 +9,10 @@ LABEL org.opencontainers.image.authors="Snowdream Tech" \
     org.opencontainers.image.licenses="MIT" \
     org.opencontainers.image.source="https://github.com/snowdreamtech/go" \
     org.opencontainers.image.vendor="Snowdream Tech" \
-    org.opencontainers.image.version="1.23.1" \
+    org.opencontainers.image.version="1.23.2" \
     org.opencontainers.image.url="https://github.com/snowdreamtech/go"
 
-ENV GOLANG_VERSION=1.23.1-3 \ 
+ENV GOLANG_VERSION=2:1.23~2 \ 
     GOROOT=/usr/lib/go-1.23 \
     PATH=$PATH:/usr/lib/go-1.23/bin \
     GO111MODULE=on \


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[docker/build-push-action](https://github.com/docker/build-push-action)** published a new release **[v6.10.0](https://github.com/docker/build-push-action/releases/tag/v6.10.0)** on 2024-11-26T10:49:47Z
* **[docker/metadata-action](https://github.com/docker/metadata-action)** published a new release **[v5.6.1](https://github.com/docker/metadata-action/releases/tag/v5.6.1)** on 2024-11-19T17:28:49Z
